### PR TITLE
Add shadowsocks option: TIMEOUT (default 3600s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
 	&& pip install supervisor-stdout
 COPY supervisord.conf /etc/supervisord.conf
 ENV KCP_MTU=1350 KCP_MODE=fast KCP_KEY=123456789 KCP_DATASHARED=5 KCP_PARITYSHARED=5 KCP_SNDWND=1024
+ENV TIMEOUT 3600
 EXPOSE 41111/udp
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM easypi/shadowsocks-libev
 RUN set -ex \
-	&& apk update \
-	&& apk add ca-certificates supervisor \
+	&& apk add --no-cache ca-certificates supervisor python py-pip \
 	&& update-ca-certificates \
-	&& apk add --update python py-pip \
-	&& rm -rf /var/cache/apk/* \
-    	&& apk add --no-cache --virtual TMP wget \
+    	&& apk add --no-cache --virtual .TMP wget \
 	&& wget -O /root/kcptun-linux-amd64.tar.gz https://github.com/xtaci/kcptun/releases/download/v20170218/kcptun-linux-amd64-20170218.tar.gz \
 	&& mkdir -p /opt/kcptun \
 	&& cd /opt/kcptun \
 	&& tar xvfz /root/kcptun-linux-amd64.tar.gz \
 	&& rm /root/kcptun-linux-amd64.tar.gz \
-   	&& apk del --virtual TMP \ 
+   	&& apk del --virtual .TMP \ 
 	&& pip install supervisor-stdout
 COPY supervisord.conf /etc/supervisord.conf
 ENV KCP_MTU=1350 KCP_MODE=fast KCP_KEY=123456789 KCP_DATASHARED=10 KCP_PARITYSHARED=3 KCP_SNDWND=128

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:ss-server]
-command=ss-server -s 0.0.0.0 -p 8388 -k %(ENV_PASSWORD)s -m %(ENV_METHOD)s -u -v
+command=ss-server -s 0.0.0.0 -p 8388 -k %(ENV_PASSWORD)s -m %(ENV_METHOD)s -u
 startsecs = 5
 stdout_events_enabled=true
 stderr_events_enabled=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:ss-server]
-command=ss-server -s 0.0.0.0 -p 8388 -k %(ENV_PASSWORD)s -m %(ENV_METHOD)s -u
+command=ss-server -s 0.0.0.0 -p 8388 -k %(ENV_PASSWORD)s -m %(ENV_METHOD)s -t %(ENV_TIMEOUT)s -u
 startsecs = 5
 stdout_events_enabled=true
 stderr_events_enabled=true


### PR DESCRIPTION
- Add shadowsocks option: `TIMEOUT`, the default value is 3600s.
- Remove -v verbose for shadowsocks `ss-server`.